### PR TITLE
The Add and Edit sticker forms will now fetch categories from the API

### DIFF
--- a/frontend/src/components/StickerForm.tsx
+++ b/frontend/src/components/StickerForm.tsx
@@ -8,6 +8,7 @@ export default function StickerForm() {
     const { productId } = useParams();
     const navigate = useNavigate();
     const { specificSticker, fetchSpecificSticker, updateSticker } = useStickerStore();
+    const [categories, setCategories] = useState<string[]>([]);
 
     const [formData, setFormData] = useState({
         title: "",
@@ -27,6 +28,20 @@ export default function StickerForm() {
             fetchSpecificSticker(productId);
         }
     }, [productId, fetchSpecificSticker]);
+
+    useEffect(() => {
+        const fetchCategories = async () => {
+            try {
+                const response = await fetch(`${BASE_URL}/categories`);
+                const data = await response.json();
+                setCategories(data.map((cat: { name: string }) => cat.name));
+            } catch (error) {
+                console.error("Failed to fetch categories:", error);
+            }
+        };
+    
+        fetchCategories();
+    }, []);    
 
     useEffect(() => {
         if (specificSticker && productId) {
@@ -153,11 +168,12 @@ export default function StickerForm() {
                 className="w-full border p-2 rounded-md mt-1"
                 required
             >
-                <option value="">Select a category</option>
-                <option value="Gaming">Gaming</option>
-                <option value="Nature">Nature</option>
-                <option value="Cartoon">Cartoon</option>
-                <option value="Animals">Animals</option>
+                {categories.map((category) => (
+                    <option key={category} value={category}>
+                        {category}
+                    </option>
+                ))}
+
             </select>
 
             <label className="block font-medium mt-4">Sticker Type</label>


### PR DESCRIPTION
The dropdown menu in "ADD" and in "EDIT" stickers will now fetch Categories from the API:

<img width="612" alt="Screenshot 2025-03-26 at 14 18 00" src="https://github.com/user-attachments/assets/38c016f4-3b46-448f-9fc5-e072be1a98f4" />
