### PR TITLE
Search bar moved to top of page under the  nav for best ux

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,13 @@
 import AllCategoriesPage from "./routes/AllCategoriesPage";
 import ProductsPage from "./routes/ProductsPage";
+import { Search } from "./components/Search";
 
 export default function App() {
-    return (
-        <>
-            <AllCategoriesPage />
-            <ProductsPage />
-        </>
-    )
+  return (
+    <>
+      <Search />
+      <AllCategoriesPage />
+      <ProductsPage />
+    </>
+  );
 }

--- a/frontend/src/Layout/Header.tsx
+++ b/frontend/src/Layout/Header.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Link } from "react-router-dom";
-import { FaSearch, FaShoppingCart, FaUser, FaHeart } from "react-icons/fa";
+import { FaShoppingCart, FaUser, FaHeart } from "react-icons/fa";
+// import { FaSearch } from "react-icons/fa";
 import { useCartStore } from "../store/CartStore";
 import { useFavouritesStore } from "../store/FavouritesStore";
 
@@ -48,7 +49,7 @@ export default function Header() {
       </nav>
 
       <div className="flex items-center gap-4">
-        <FaSearch className="primary-text cursor-pointer hover:text-secondary-text" />
+        {/* <FaSearch className="primary-text cursor-pointer hover:text-secondary-text" /> */}
 
         <Link to="/favourites" className="relative">
           <FaHeart className="primary-text cursor-pointer hover:text-secondary-text" />

--- a/frontend/src/Layout/MobileHeader.tsx
+++ b/frontend/src/Layout/MobileHeader.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useRef, useState } from "react";
-import { FaSearch, FaShoppingCart, FaHeart } from "react-icons/fa";
+import { FaShoppingCart, FaHeart } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { useCartStore } from "../store/CartStore";
 import { useFavouritesStore } from "../store/FavouritesStore";
-import { MobileSearch } from "../components/MobileSearch";
 
 export default function MobileHeader() {
   const { getTotalItems } = useCartStore();
@@ -13,23 +11,6 @@ export default function MobileHeader() {
     (state) => state.favourites.length
   );
 
-  const [showSearch, setShowSearch] = useState(false);
-  const searchRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        searchRef.current &&
-        !searchRef.current.contains(event.target as Node)
-      ) {
-        setShowSearch(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
   return (
     <header className="flex justify-between items-center p-4 bg-white shadow-md relative">
       <Link to="/" className="text-lg font-bold">
@@ -37,13 +18,6 @@ export default function MobileHeader() {
       </Link>
 
       <div className="flex items-center gap-4">
-        <button
-          className="text-black hover:text-secondary-text"
-          onClick={() => setShowSearch(!showSearch)}
-        >
-          <FaSearch size={18} />
-        </button>
-
         <Link to="/favourites" className="relative">
           <FaHeart size={20} className="text-black hover:text-secondary-text" />
           {favouritesCount > 0 && (
@@ -64,15 +38,6 @@ export default function MobileHeader() {
           )}
         </div>
       </div>
-
-      {showSearch && (
-        <div
-          className="absolute top-full left-0 right-0 p-4 bg-white shadow z-10"
-          ref={searchRef}
-        >
-          <MobileSearch setShowSearch={setShowSearch} />
-        </div>
-      )}
     </header>
   );
 }

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -1,39 +1,44 @@
-import { useState } from "react";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { useStickerStore } from "../store/stickerStore";
-import { Sticker } from "../types/sticker";
+import { FaSearch } from "react-icons/fa";
 
-interface SearchProps {
-    setResults: (results: Sticker[]) => void;
-}
+export function Search() {
+  const { searchQuery, setSearchQuery } = useStickerStore();
+  const location = useLocation();
 
-export function Search({ setResults }: SearchProps) {
-    const [input, setInput] = useState("");
-    const { stickers } = useStickerStore();
+  useEffect(() => {
+    setSearchQuery("");
+  }, [location.pathname, setSearchQuery]);
 
-    const filterProducts = (value: string) => {
-        setInput(value);
+  const handleSearch = () => {
+    console.log("Search triggered:", searchQuery);
+  };
 
-        if (!value) {
-            setResults(stickers);
-            return;
-        }
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSearch();
+    }
+  };
 
-        const filteredResults = stickers.filter((product) =>
-            product.title.toLowerCase().includes(value.toLowerCase())
-        );
-
-        setResults(filteredResults);
-    };
-
-    return (
-        <div className="relative w-full max-w-md">
-            <input
-                className="border rounded p-2 w-full focus:ring-2 focus:ring-blue-500 outline-none"
-                type="text"
-                placeholder="search products..."
-                value={input}
-                onChange={(e) => filterProducts(e.target.value)}
-            />
-        </div>
-    );
+  return (
+    <div className="w-full max-w-3xl mx-auto my-4 px-4">
+      <div className="flex rounded-xl shadow-sm border focus-within:ring-2 focus-within:ring-primary overflow-hidden">
+        <input
+          className="flex-grow px-4 py-2 focus:outline-none"
+          type="text"
+          placeholder="Search stickers..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          onClick={handleSearch}
+          className="px-4 bg-primary text-white hover:bg-primary-hover transition"
+        >
+          <FaSearch />
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,6 +22,7 @@ import AdminLayout from "./routes/AdminPage/AdminLayout";
 import { Toaster } from "react-hot-toast";
 import AccountPage from "./routes/AccountPage";
 import FavouritesPage from "./routes/FavouritesPage";
+import ShopPage from "./routes/ShopPage";
 
 const router = createBrowserRouter([
   {
@@ -39,10 +40,10 @@ const router = createBrowserRouter([
       {
         path: "category/:categoryId/:product_type",
         element: <CategoryDetailsPage />,
-      },         
+      },
       {
         path: "products",
-        element: <ProductsPage />,
+        element: <ShopPage />,
       },
       {
         path: "products/:productId",
@@ -59,7 +60,7 @@ const router = createBrowserRouter([
       {
         path: "/checkout-success",
         element: <CheckoutSuccessPage />,
-      },      
+      },
       {
         path: "favourites",
         element: <FavouritesPage />,

--- a/frontend/src/routes/ProductsPage/index.tsx
+++ b/frontend/src/routes/ProductsPage/index.tsx
@@ -1,41 +1,79 @@
 import ProductCard from "../../components/ProductCard";
-import { useFetchStickers } from "../../hooks/useFetchStickers";
+import { useStickerStore } from "../../store/stickerStore";
+import { useEffect } from "react";
 import { Loading } from "../../utilities/loading";
 import { ErrorMessage } from "../../utilities/errorMessage";
 
-import { Search } from "../../components/Search";
-import { useState, useEffect } from "react";
-import { Sticker } from "../../types/sticker";
-
-export default function ShopPage() {
-  const { stickers, loading, error } = useFetchStickers();
-  const [searchResults, setSearchResults] = useState<Sticker[]>([]);
+export default function ProductsPage() {
+  const { stickers, searchQuery, fetchStickers, loading, error } =
+    useStickerStore();
 
   useEffect(() => {
-    setSearchResults(stickers);
-  }, [stickers]);
+    fetchStickers();
+  }, [fetchStickers]);
+
+  const filtered = stickers.filter((sticker) =>
+    sticker.title.toLowerCase().includes(searchQuery.toLowerCase())
+  );
 
   if (loading) return <Loading />;
   if (error) return <ErrorMessage message={error} />;
 
   return (
-    <>
-      <div className="flex w-full justify-center m-4">
-        <Search setResults={setSearchResults} />
+    <div className="w-full flex justify-center pb-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 p-6 mx-auto items-start">
+        {filtered.length > 0 ? (
+          filtered.map((sticker) => (
+            <ProductCard key={sticker.id} product={sticker} mode="customer" />
+          ))
+        ) : (
+          <div className="col-span-full text-center text-gray-500">
+            No results found.
+          </div>
+        )}
       </div>
-      <div className="w-full flex justify-center pb-4">
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 p-6 mx-auto items-start">
-          {searchResults.length > 0 ? (
-            searchResults.map((sticker) => (
-              <ProductCard key={sticker.id} product={sticker} mode="customer" />
-            ))
-          ) : (
-            <div className="col-span-full text-center text-gray-500">
-              No results found.
-            </div>
-          )}
-        </div>
-      </div>
-    </>
+    </div>
   );
 }
+
+// import ProductCard from "../../components/ProductCard";
+// import { useFetchStickers } from "../../hooks/useFetchStickers";
+// import { Loading } from "../../utilities/loading";
+// import { ErrorMessage } from "../../utilities/errorMessage";
+
+// import { Search } from "../../components/Search";
+// import { useState, useEffect } from "react";
+// import { Sticker } from "../../types/sticker";
+
+// export default function ShopPage() {
+//   const { stickers, loading, error } = useFetchStickers();
+//   const [searchResults, setSearchResults] = useState<Sticker[]>([]);
+
+//   useEffect(() => {
+//     setSearchResults(stickers);
+//   }, [stickers]);
+
+//   if (loading) return <Loading />;
+//   if (error) return <ErrorMessage message={error} />;
+
+//   return (
+//     <>
+//       <div className="flex w-full justify-center m-4">
+//         <Search setResults={setSearchResults} />
+//       </div>
+//       <div className="w-full flex justify-center pb-4">
+//         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 p-6 mx-auto items-start">
+//           {searchResults.length > 0 ? (
+//             searchResults.map((sticker) => (
+//               <ProductCard key={sticker.id} product={sticker} mode="customer" />
+//             ))
+//           ) : (
+//             <div className="col-span-full text-center text-gray-500">
+//               No results found.
+//             </div>
+//           )}
+//         </div>
+//       </div>
+//     </>
+//   );
+// }

--- a/frontend/src/routes/ShopPage/index.tsx
+++ b/frontend/src/routes/ShopPage/index.tsx
@@ -1,0 +1,11 @@
+import { Search } from "../../components/Search";
+import ProductsPage from "../ProductsPage"; // This still works fine!
+
+export default function ShopPage() {
+  return (
+    <>
+      <Search />
+      <ProductsPage />
+    </>
+  );
+}

--- a/frontend/src/store/stickerStore.ts
+++ b/frontend/src/store/stickerStore.ts
@@ -3,95 +3,113 @@ import { Sticker } from "../types/sticker";
 import { BASE_URL } from "../constants";
 
 interface StickerState {
-    stickers: Sticker[];
-    specificSticker: Sticker | null;
-    loading: boolean;
-    error: string | null;
-    fetchStickers: () => Promise<void>;
-    fetchSpecificSticker: (productId: string) => Promise<void>;
-    deleteSticker: (productId: number) => Promise<void>;
-    updateSticker: (productId: string, updatedData: Partial<Sticker>) => Promise<void>;
-    setStickers: (stickers: Sticker[]) => void;
+  stickers: Sticker[];
+  specificSticker: Sticker | null;
+  loading: boolean;
+  error: string | null;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  fetchStickers: () => Promise<void>;
+  fetchSpecificSticker: (productId: string) => Promise<void>;
+  deleteSticker: (productId: number) => Promise<void>;
+  updateSticker: (
+    productId: string,
+    updatedData: Partial<Sticker>
+  ) => Promise<void>;
+  setStickers: (stickers: Sticker[]) => void;
 }
 
 export const useStickerStore = create<StickerState>((set) => ({
-    stickers: [],
-    specificSticker: null,
-    loading: false,
-    error: null,
+  stickers: [],
+  specificSticker: null,
+  loading: false,
+  error: null,
+  searchQuery: "",
+  setSearchQuery: (query) => set({ searchQuery: query }),
 
-    fetchStickers: async () => {
-        set({ loading: true, error: null });
-        try {
-            const response = await fetch(`${BASE_URL}/stickers`);
-            if (!response.ok) throw new Error(`Failed to fetch stickers: ${response.status}`);
+  fetchStickers: async () => {
+    set({ loading: true, error: null });
+    try {
+      const response = await fetch(`${BASE_URL}/stickers`);
+      if (!response.ok)
+        throw new Error(`Failed to fetch stickers: ${response.status}`);
 
-            const result = await response.json();
-            set({ stickers: Array.isArray(result) ? result : result.data || [], loading: false });
-        } catch (err) {
-            console.error("Error fetching stickers:", err);
-            set({
-                loading: false,
-                error: err instanceof Error ? err.message : "Unknown error",
-                stickers: [],
-            });
-        }
-    },
+      const result = await response.json();
+      set({
+        stickers: Array.isArray(result) ? result : result.data || [],
+        loading: false,
+      });
+    } catch (err) {
+      console.error("Error fetching stickers:", err);
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+        stickers: [],
+      });
+    }
+  },
 
-    fetchSpecificSticker: async (productId: string) => {
-        set({ loading: true, error: null });
-        try {
-            const response = await fetch(`${BASE_URL}/stickers/${productId}`);
-            if (!response.ok) throw new Error(`Failed to fetch sticker: ${response.status} - ${response.statusText}`);
+  fetchSpecificSticker: async (productId: string) => {
+    set({ loading: true, error: null });
+    try {
+      const response = await fetch(`${BASE_URL}/stickers/${productId}`);
+      if (!response.ok)
+        throw new Error(
+          `Failed to fetch sticker: ${response.status} - ${response.statusText}`
+        );
 
-            const result = await response.json();
-            set({ specificSticker: result, loading: false });
-        } catch (err) {
-            console.error("Error fetching specific sticker:", err);
-            set({
-                loading: false,
-                error: err instanceof Error ? err.message : "Unknown error",
-                specificSticker: null,
-            });
-        }
-    },
+      const result = await response.json();
+      set({ specificSticker: result, loading: false });
+    } catch (err) {
+      console.error("Error fetching specific sticker:", err);
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+        specificSticker: null,
+      });
+    }
+  },
 
-    updateSticker: async (productId: string, updatedData: Partial<Sticker>) => {
-        try {
-            const response = await fetch(`${BASE_URL}/stickers/${productId}`, {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(updatedData),
-            });
+  updateSticker: async (productId: string, updatedData: Partial<Sticker>) => {
+    try {
+      const response = await fetch(`${BASE_URL}/stickers/${productId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updatedData),
+      });
 
-            if (!response.ok) throw new Error(`Failed to update sticker: ${response.status}`);
+      if (!response.ok)
+        throw new Error(`Failed to update sticker: ${response.status}`);
 
-            set((state) => ({
-                stickers: state.stickers.map((sticker) =>
-                    sticker.id === Number(productId) ? { ...sticker, ...updatedData } : sticker
-                ),
-            }));
-        } catch (err) {
-            console.error("Error updating sticker:", err);
-            set({ error: err instanceof Error ? err.message : "Unknown error" });
-        }
-    },
+      set((state) => ({
+        stickers: state.stickers.map((sticker) =>
+          sticker.id === Number(productId)
+            ? { ...sticker, ...updatedData }
+            : sticker
+        ),
+      }));
+    } catch (err) {
+      console.error("Error updating sticker:", err);
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
 
-    deleteSticker: async (productId: number) => {
-        try {
-            const response = await fetch(`${BASE_URL}/stickers/${productId}`, {
-                method: "DELETE",
-            });
-            if (!response.ok) throw new Error(`Failed to delete sticker: ${response.status}`);
+  deleteSticker: async (productId: number) => {
+    try {
+      const response = await fetch(`${BASE_URL}/stickers/${productId}`, {
+        method: "DELETE",
+      });
+      if (!response.ok)
+        throw new Error(`Failed to delete sticker: ${response.status}`);
 
-            set((state) => ({
-                stickers: state.stickers.filter((product) => product.id !== productId),
-            }));
-        } catch (err) {
-            console.error("Error deleting sticker:", err);
-            set({ error: err instanceof Error ? err.message : "Unknown error" });
-        }
-    },
+      set((state) => ({
+        stickers: state.stickers.filter((product) => product.id !== productId),
+      }));
+    } catch (err) {
+      console.error("Error deleting sticker:", err);
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
 
-    setStickers: (stickers: Sticker[]) => set({ stickers }),
+  setStickers: (stickers: Sticker[]) => set({ stickers }),
 }));


### PR DESCRIPTION
Search bar moved to top of page under the  nav for best ux. some improved design and search icon button. search still automatically search, but will also work with clicking button or pressing enter. The search bar used to be together with the code that shows all cards on ProductsPage/index.tsx. Now the search is split from that, and whats left is only code to show all cards. Search and its design can be edited in search component. Made a own page called ShopPage where it takes in ProductsPage and ShopPage. If we want to later, we can move search to whereever we like. for example inside the nav. This actually fixed the other problem we had with nav bar leaving som space to the left when scaling down. cause the search was sticking out :)